### PR TITLE
Adding Semantic UI with some changes I missed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,5 @@ node_modules/
 .idea/
 public/
 npm-debug.log
-*.sublime*
+*.sublime
+bower_components/

--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,20 @@
+{
+  "name": "apiary",
+  "version": "0.0.0",
+  "homepage": "https://github.com/streisand/apiary",
+  "authors": [
+    "uzarubin <ustin.zarubin@getbellhops.com>",
+    "hwkns <daniel.hawkins@getbellhops.com>"
+  ],
+  "license": "MIT",
+  "ignore": [
+    "**/.*",
+    "node_modules",
+    "bower_components",
+    "test",
+    "tests"
+  ],
+  "dependencies": {
+    "semantic-ui-icon": "~1.11.7"
+  }
+}

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -8,7 +8,7 @@ var reload     = connect.reload;
 var sass       = require('gulp-sass');
 var neat       = require('node-neat');
 
-gulp.task('default', ['js', 'connect', 'nodemon', 'watch']);
+gulp.task('default', ['js', 'sass', 'fonts', 'connect', 'nodemon', 'watch']);
 
 
 gulp.task('js', function() {
@@ -29,6 +29,11 @@ gulp.task('sass', function() {
     .pipe(reload());
 });
 
+gulp.task('fonts', function() {
+  gulp.src('./bower_components/semantic-ui-icon/assets/fonts/*')
+    .pipe(gulp.dest('public/css/assets/fonts/'));
+});
+
 gulp.task('watch', function() {
   gulp.watch('./src/js/**/*.js', ['js']);
   gulp.watch('./src/styles/**/*.scss', ['sass']);
@@ -42,6 +47,6 @@ gulp.task('connect', function() {
 });
 
 gulp.task('nodemon', function() {
-  return nodemon({script: './bin/www'})
+  return nodemon({script: './bin/www'});
 
 });

--- a/package.json
+++ b/package.json
@@ -26,13 +26,14 @@
     "morgan": "~1.3.0",
     "node-bourbon": "^4.2.1-beta1",
     "node-neat": "^1.7.1-beta1",
+    "node-sass": "^2.1.1",
     "react": "^0.13.1",
     "scgi-stream": "^0.3.1",
     "serve-favicon": "~2.1.3",
     "socket.io": "^1.3.5",
     "swig": "^1.4.2",
-    "xmlrpc-stream": "0.0.1",
-    "xmlrpc": "^1.3.0"
+    "xmlrpc": "^1.3.0",
+    "xmlrpc-stream": "0.0.1"
   },
   "devDependencies": {
     "browserify": "^9.0.3",

--- a/routes/index.js
+++ b/routes/index.js
@@ -1,15 +1,5 @@
 var express = require('express');
 var router = express.Router();
-var scgi = require("scgi-stream");
-var RPC  = require("xmlrpc-stream");
-
-var rpc = new RPC(function() {
-  return scgi.duplex({
-    host: "127.0.0.1",
-    port: 4000,
-    path: "/"
-  });
-});
 
 /* GET home page. */
 router.get('/', function(req, res) {

--- a/src/js/components/Icon.js
+++ b/src/js/components/Icon.js
@@ -1,0 +1,13 @@
+var React = require('react');
+
+var Icon = React.createClass({
+  
+  render: function() {
+    return (
+      <i {...this.props}>{this.props.children}</i>
+    );
+  }
+
+});
+
+module.exports = Icon;

--- a/src/js/components/Torrent.js
+++ b/src/js/components/Torrent.js
@@ -1,18 +1,19 @@
 var React = require('react');
+var Icon = require('./Icon');
 
 var Torrent = React.createClass({
 
   getInitialState: function() {
     return {
       torrent: {}
-    }
+    };
   },
 
   render: function() {
     return (
       <div id={this.props.infoHash} className="torrent">
         <div className="status-container">
-          <div className="status-info">Status</div>
+          <Icon className='arrow circle outline down icon'/>          
         </div>
         <div className="torrent-info">
           <div className="torrent-name">
@@ -28,7 +29,7 @@ var Torrent = React.createClass({
           </div>
         </div>
       </div>
-    )
+    );
   },
 
   getRatioUpOverDown: function() {
@@ -47,7 +48,7 @@ var Torrent = React.createClass({
   },
 
   bytesToSize: function(bytes) {
-    if(bytes == 0) return '0 B';
+    if(bytes === 0) return '0 B';
     var k = 1024 ;
     var sizes = ['B', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB'];
     var i = Math.floor(Math.log(bytes) / Math.log(k));
@@ -57,4 +58,3 @@ var Torrent = React.createClass({
 });
 
 module.exports = Torrent;
-

--- a/src/js/components/Torrents.js
+++ b/src/js/components/Torrents.js
@@ -30,7 +30,7 @@ var MainPage = React.createClass({
   render: function() {
     return (
       <div className="main-container">
-      {this.renderTorrents()}
+        {this.renderTorrents()}
       </div>
     );
   },

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -1,17 +1,23 @@
 @import "bourbon";
 @import "neat";
-
+@import "../../bower_components/semantic-ui-icon/icon";
 
 #main-content {
   @include outer-container;
-
   .torrent {
     @include span-columns(12 of 12);
+    display: flex;
+    margin-bottom: em(20);
+    border-bottom: 1px solid black;
     .status-container {
-      @include span-columns(2 of 12, block-collapse);
+      @include span-columns(2 of 12);
+      align-self: center;
+      .icon {
+        font-size: 2em;   
+      }
     }
     .torrent-info {
-      @include span-columns(10 of 12, block-collapse);
+      @include span-columns(10 of 12);
     }
   }
 }


### PR DESCRIPTION
Adding semantic UI. Please review, but don't merge it until #7 has been merged. 

Semantic UI is added through bower and `bower install` will install it. 

I went ahead and created "fonts" task in gulp and that grab fonts from bower_components and place them into the public directory. This was needed because of Semantic UI's font dependencies and I didn't want to bundle them with this project. 

the `Icon` component was created to make an abstraction for the icons. 
